### PR TITLE
Bugfix for: 0009170: New quest markers appear too high

### DIFF
--- a/illaclient/src/illarion/client/graphics/QuestMarker.java
+++ b/illaclient/src/illarion/client/graphics/QuestMarker.java
@@ -127,9 +127,8 @@ public class QuestMarker extends AbstractEntity<MiscImageTemplate> {
 
     @Override
     public void show() {
-        appliedOffset = parentTile.getQuestMarkerElevation();
         final Location loc = parentTile.getLocation();
-        setScreenPos(loc.getDcX(), loc.getDcY() - appliedOffset, loc.getDcZ(), Layers.OVERLAYS);
+        setScreenPos(loc.getDcX(), loc.getDcY(), loc.getDcZ(), Layers.OVERLAYS);
 
         super.show();
     }


### PR DESCRIPTION
http://illarion.org/mantis/view.php?id=9170
Questmarkers were displayed too high above a tile. This is corrected by not using "appliedOffset"
