### PR TITLE
[MapEditor] Refactor class 'MapSelection' to hide implementation details

### DIFF
--- a/illamapedit/src/main/java/illarion/mapedit/data/AnnotationChecker.java
+++ b/illamapedit/src/main/java/illarion/mapedit/data/AnnotationChecker.java
@@ -48,7 +48,7 @@ public class AnnotationChecker {
     public boolean isAnnotated(
             final int x, final int y, @Nonnull final Map map, @Nonnull final MapSelection mapSelection) {
         final List<String[]> annotatedTiles = new ArrayList<>();
-        for (final MapPosition position : mapSelection.getTiles().keySet()) {
+        for (final MapPosition position : mapSelection.getSelectedPositions()) {
             final int newX = x + (position.getX() - mapSelection.getOffsetX());
             final int newY = y + (position.getY() - mapSelection.getOffsetY());
             if (map.contains(newX, newY)) {

--- a/illamapedit/src/main/java/illarion/mapedit/data/Map.java
+++ b/illamapedit/src/main/java/illarion/mapedit/data/Map.java
@@ -454,13 +454,13 @@ public class Map implements Iterable<MapTile> {
      */
     public void pasteTiles(final int startX, final int startY, @Nonnull final MapSelection mapSelection) {
         final GroupAction action = new GroupAction();
-        for (final MapPosition position : mapSelection.getTiles().keySet()) {
+        for (final MapPosition position : mapSelection.getSelectedPositions()) {
             final int newX = startX + (position.getX() - mapSelection.getOffsetX());
             final int newY = startY + (position.getY() - mapSelection.getOffsetY());
 
             if (contains(newX, newY)) {
                 final MapTile oldTile = getTileAt(newX, newY);
-                final MapTile newTile = MapTile.MapTileFactory.copy(mapSelection.getTiles().get(position));
+                final MapTile newTile = MapTile.MapTileFactory.copy(mapSelection.getMapTileAt(position));
                 action.addAction(new CopyPasteAction(newX, newY, oldTile, newTile, this));
                 setTileAt(newX, newY, newTile);
             }

--- a/illamapedit/src/main/java/illarion/mapedit/data/MapSelection.java
+++ b/illamapedit/src/main/java/illarion/mapedit/data/MapSelection.java
@@ -16,6 +16,8 @@
 package illarion.mapedit.data;
 
 import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 
 /**
@@ -67,7 +69,11 @@ public class MapSelection {
     }
 
     @Nonnull
-    public HashMap<MapPosition, MapTile> getTiles() {
-        return selectedTiles;
+    public Collection<MapPosition> getSelectedPositions() {
+        return Collections.unmodifiableCollection(selectedTiles.keySet());
+    }
+
+    public MapTile getMapTileAt(MapPosition position) {
+        return selectedTiles.get(position);
     }
 }

--- a/illamapedit/src/test/java/illarion/mapedit/data/MapSelectionTest.java
+++ b/illamapedit/src/test/java/illarion/mapedit/data/MapSelectionTest.java
@@ -19,6 +19,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Collection;
 import java.util.HashMap;
 
 /**
@@ -37,10 +38,10 @@ public class MapSelectionTest {
 
     @Test
     public void testInitialState() {
-        HashMap<MapPosition,MapTile> tiles = mapSelection.getTiles();
+        Collection<MapPosition> selectedPositions = mapSelection.getSelectedPositions();
 
-        Assert.assertNotNull(tiles, "Tiles must not be null");
-        Assert.assertEquals(tiles.size(), 0, "tiles should be empty");
+        Assert.assertNotNull(selectedPositions, "Collection of selected positions must not be null");
+        Assert.assertEquals(selectedPositions.size(), 0, "No position should be selected");
         Assert.assertEquals(mapSelection.getOffsetX(), Integer.MAX_VALUE, "Expected offset equal to max. integer value");
         Assert.assertEquals(mapSelection.getOffsetY(), Integer.MAX_VALUE, "Expected offset equal to max. integer value");
     }
@@ -51,7 +52,7 @@ public class MapSelectionTest {
         int verticalPosition = 7;
         addSelectedTileAt(horizontalPosition, verticalPosition);
 
-        Assert.assertEquals(mapSelection.getTiles().size(), 1);
+        Assert.assertEquals(mapSelection.getSelectedPositions().size(), 1);
         Assert.assertEquals(mapSelection.getOffsetX(), horizontalPosition);
         Assert.assertEquals(mapSelection.getOffsetY(), verticalPosition);
     }
@@ -63,7 +64,7 @@ public class MapSelectionTest {
 
         Assert.assertEquals(mapSelection.getOffsetX(), 5);
         Assert.assertEquals(mapSelection.getOffsetY(), 4);
-        Assert.assertEquals(mapSelection.getTiles().size(), 2);
+        Assert.assertEquals(mapSelection.getSelectedPositions().size(), 2);
     }
 
     @Test
@@ -73,7 +74,7 @@ public class MapSelectionTest {
 
         Assert.assertEquals(mapSelection.getOffsetX(), 4);
         Assert.assertEquals(mapSelection.getOffsetY(), 5);
-        Assert.assertEquals(mapSelection.getTiles().size(), 2);
+        Assert.assertEquals(mapSelection.getSelectedPositions().size(), 2);
     }
 
     @Test
@@ -84,7 +85,7 @@ public class MapSelectionTest {
 
         Assert.assertEquals(mapSelection.getOffsetX(), 4);
         Assert.assertEquals(mapSelection.getOffsetY(), 3);
-        Assert.assertEquals(mapSelection.getTiles().size(), 3);
+        Assert.assertEquals(mapSelection.getSelectedPositions().size(), 3);
     }
 
     private MapTile createTile() {


### PR DESCRIPTION
Refactored class 'MapSelection' in an effort to hide implementation details, e.g. the fact that a HashMap is used as an internal data structure.
