### PR TITLE
[client] Issue 7799: Hide tooltip when closing containers/inventory

### DIFF
--- a/illaclient/src/main/java/illarion/client/graphics/AbstractEntity.java
+++ b/illaclient/src/main/java/illarion/client/graphics/AbstractEntity.java
@@ -15,8 +15,11 @@
  */
 package illarion.client.graphics;
 
+import illarion.client.input.ClickOnMapEvent;
 import illarion.client.resources.data.AbstractEntityTemplate;
+import illarion.client.world.MapTile;
 import illarion.client.world.World;
+import illarion.client.world.movement.TargetMovementHandler;
 import illarion.common.types.Location;
 import illarion.common.types.Rectangle;
 import illarion.common.util.FastMath;
@@ -25,6 +28,7 @@ import org.illarion.engine.GameContainer;
 import org.illarion.engine.graphic.*;
 import org.illarion.engine.graphic.effects.HighlightEffect;
 import org.illarion.engine.graphic.effects.TextureEffect;
+import org.illarion.engine.input.Button;
 import org.illarion.engine.input.Input;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -560,8 +564,36 @@ public abstract class AbstractEntity<T extends AbstractEntityTemplate>
     @Override
     public boolean isEventProcessed(
             @Nonnull GameContainer container, int delta, @Nonnull SceneEvent event) {
+
         return false;
     }
+
+    /**
+     * Handles clicking on the map for any type of entity.
+     * If possible, walks the character to the location at the tile under the mouse
+     * Does not walk the player to the base of objects or avatars.
+     *
+     * @param event the event to be processed
+     * @param container the GameContainer; needed to process input
+     * @return  {@code true} if the event was processed
+     */
+    protected boolean processMapClick(@Nonnull ClickOnMapEvent event, @Nonnull GameContainer container){
+        if (event.getKey() != Button.Left) {
+            return false;
+        }
+        MapTile mouseTile = World.getMap().getInteractive().getTileOnScreenLoc(container.getEngine().getInput().getMouseX(), container.getEngine().getInput().getMouseY());
+        
+        if(!mouseTile.isAtPlayerLevel()){
+            return false;
+        }
+
+        TargetMovementHandler handler = World.getPlayer().getMovementHandler().getTargetMovementHandler();
+        boolean blocked = mouseTile.isBlocked();
+        handler.walkTo(mouseTile.getLocation(), (blocked ? 1 : 0));
+        handler.assumeControl();
+        return true;
+    }
+
 
     protected boolean isMouseInInteractionRect(int mouseX, int mouseY) {
         int mouseXonDisplay = mouseX + Camera.getInstance().getViewportOffsetX();

--- a/illaclient/src/main/java/illarion/client/graphics/Item.java
+++ b/illaclient/src/main/java/illarion/client/graphics/Item.java
@@ -265,6 +265,13 @@ public final class Item extends AbstractEntity<ItemTemplate> implements Resource
         return true;
     }
 
+    /**
+     * The default way that the game handles clicking on an item
+     * The processMapClick method in AbstractEntity replaces this
+     *
+     * @param event the event to process
+     * @return      true if the method is processed properly
+     */
     private boolean isEventProcessed(@Nonnull ClickOnMapEvent event) {
         if (event.getKey() != Button.Left) {
             return false;
@@ -363,8 +370,9 @@ public final class Item extends AbstractEntity<ItemTemplate> implements Resource
                     return isEventProcessed((PointOnMapEvent) event);
                 }
 
+                // Uses a method from AbstractEntity that walks the player to the point at the mouse
                 if (event instanceof ClickOnMapEvent) {
-                    return isEventProcessed((ClickOnMapEvent) event);
+                    return processMapClick((ClickOnMapEvent) event, container);
                 }
 
                 if (event instanceof DoubleClickOnMapEvent) {

--- a/illaclient/src/main/java/illarion/client/gui/controller/game/ContainerHandler.java
+++ b/illaclient/src/main/java/illarion/client/gui/controller/game/ContainerHandler.java
@@ -444,13 +444,20 @@ public final class ContainerHandler implements ContainerGui, ScreenController {
 
     }
 
+    /**
+     * Closes the given container
+     * Hides the current ToolTip
+     * @param containerId the ID of the container to close
+     */
     @Override
     public void closeContainer(final int containerId) {
         World.getUpdateTaskManager().addTask(new UpdateTask() {
             @Override
             public void onUpdateGame(@Nonnull GameContainer container, int delta) {
                 if (isContainerCreated(containerId)) {
+                    tooltipHandler.hideToolTip();
                     removeItemContainer(containerId);
+
                 }
             }
         });

--- a/illaclient/src/main/java/illarion/client/gui/controller/game/GUIInventoryHandler.java
+++ b/illaclient/src/main/java/illarion/client/gui/controller/game/GUIInventoryHandler.java
@@ -241,12 +241,17 @@ public final class GUIInventoryHandler implements InventoryGui, ScreenController
         });
     }
 
+    /**
+     * Hide the inventory window from view
+     * Hides the current ToolTip
+     */
     @Override
     public void hideInventory() {
         World.getUpdateTaskManager().addTask(new UpdateTask() {
             @Override
             public void onUpdateGame(@Nonnull GameContainer container, int delta) {
                 if (inventoryWindow != null) {
+                    tooltipHandler.hideToolTip();
                     inventoryWindow.hide();
                 }
             }


### PR DESCRIPTION
Does not hide the tooltip when moving, as per nitram's recommendation.