### PR TITLE
[Client] 10875, 10277 check null coordinates, improve click-navigation

### DIFF
--- a/illaclient/src/main/java/illarion/client/IllaClient.java
+++ b/illaclient/src/main/java/illarion/client/IllaClient.java
@@ -203,24 +203,10 @@ public final class IllaClient implements EventTopicSubscriber<ConfigChangedEvent
         }
 
         try {
-            int requestedWidth;
-            int requestedHeight;
-            boolean fullScreenMode;
 
-            if (cfg.getBoolean(CFG_FULLSCREEN)) {
-                fullScreenMode = true;
-                requestedHeight = res.getHeight();
-                requestedWidth = res.getWidth();
-            } else {
-                fullScreenMode = false;
-                int windowedWidth = cfg.getInteger("windowWidth");
-                int windowedHeight = cfg.getInteger("windowHeight");
-                requestedHeight = (windowedHeight < 0) ? res.getHeight() : windowedHeight;
-                requestedWidth = (windowedWidth < 0) ? res.getWidth() : windowedWidth;
-            }
-
+            boolean fullScreenMode = cfg.getBoolean(CFG_FULLSCREEN);
             gameContainer = EngineManager
-                    .createDesktopGame(Backend.libGDX, game, requestedWidth, requestedHeight, fullScreenMode);
+                    .createDesktopGame(Backend.libGDX, game, res.getWidth(), res.getHeight(), fullScreenMode);
         } catch (@Nonnull EngineException e) {
             LOGGER.error("Fatal error creating game screen!!!", e);
             System.exit(-1);
@@ -481,10 +467,10 @@ public final class IllaClient implements EventTopicSubscriber<ConfigChangedEvent
         cfg.setDefault("soundOn", true);
         cfg.setDefault("soundVolume", Player.MAX_CLIENT_VOL);
         cfg.setDefault("musicOn", true);
-        cfg.setDefault("musicVolume", Player.MAX_CLIENT_VOL * 0.75f);
+        cfg.setDefault("musicVolume", Player.MAX_CLIENT_VOL * 0.25f);
         cfg.setDefault(ChatLog.CFG_TEXTLOG, true);
         cfg.setDefault(CFG_FULLSCREEN, false);
-        cfg.setDefault(CFG_RESOLUTION, new GraphicResolution(800, 600, 32, 60).toString());
+        cfg.setDefault(CFG_RESOLUTION, new GraphicResolution().toString());
         cfg.setDefault("windowWidth", -1);
         cfg.setDefault("windowHeight", -1);
         cfg.setDefault("savePassword", false);

--- a/illaclient/src/main/java/illarion/client/graphics/AbstractEntity.java
+++ b/illaclient/src/main/java/illarion/client/graphics/AbstractEntity.java
@@ -533,33 +533,6 @@ public abstract class AbstractEntity<T extends AbstractEntityTemplate>
         return false;
     }
 
-    /**
-     * Handles clicking on the map for any type of entity.
-     * If possible, walks the character to the location at the tile under the mouse
-     * Does not walk the player to the base of objects or avatars.
-     *
-     * @param event     the event to be processed
-     * @param container the GameContainer; needed to process input
-     * @return {@code true} if the event was processed
-     */
-    protected boolean processMapClick(@Nonnull ClickOnMapEvent event, @Nonnull GameContainer container) {
-        if (event.getKey() != Button.Left) {
-            return false;
-        }
-        MapTile mouseTile = World.getMap().getInteractive().getTileOnScreenLoc(container.getEngine().getInput().getMouseX(), container.getEngine().getInput().getMouseY());
-
-        if (!mouseTile.isAtPlayerLevel()) {
-            return false;
-        }
-
-        TargetMovementHandler handler = World.getPlayer().getMovementHandler().getTargetMovementHandler();
-        boolean blocked = mouseTile.isBlocked();
-        handler.walkTo(mouseTile.getCoordinates(), (blocked ? 1 : 0));
-        handler.assumeControl();
-        return true;
-    }
-
-
     protected boolean isMouseInInteractionRect(int mouseX, int mouseY) {
         int mouseXonDisplay = mouseX + Camera.getInstance().getViewportOffsetX();
         int mouseYonDisplay = mouseY + Camera.getInstance().getViewportOffsetY();

--- a/illaclient/src/main/java/illarion/client/graphics/Item.java
+++ b/illaclient/src/main/java/illarion/client/graphics/Item.java
@@ -276,7 +276,6 @@ public final class Item extends AbstractEntity<ItemTemplate> implements Resource
      * @return {@code true} if the event was processed
      */
     protected boolean processMapClick(@Nonnull ClickOnMapEvent event, @Nonnull GameContainer container) {
-        //return isEventProcessed(event);
         if (event.getKey() != Button.Left) {
             return false;
         }
@@ -287,31 +286,24 @@ public final class Item extends AbstractEntity<ItemTemplate> implements Resource
             return false;
         }
         delayGoToItem.reset();
-        log.trace("Single clicking tile: {}", mouseTile);
 
         TargetMovementHandler handler = World.getPlayer().getMovementHandler().getTargetMovementHandler();
 
         boolean mouseTileIsBlocked = mouseTile.isBlocked();
+        boolean mouseTileInUseRange = mouseTile.getInteractive().isInUseRange();
         boolean itemClickedIsBlocked = parentTile.isBlocked();
         boolean itemClickedInUseRange = parentTile.getInteractive().isInUseRange();
-        boolean mouseTileInUseRange = mouseTile.getInteractive().isInUseRange();
 
         if (mouseTileInUseRange && mouseTileIsBlocked){
             // If it is adjacent and blocked, nowhere to walk
             return true;
         }
         if (itemClickedInUseRange) {
-            log.trace("Clicked item {} is inside of use range.", getItemId());
             if (itemClickedIsBlocked) {
-
-                log.trace("Delaying move to accept double click.");
                 delayGoToItem.setLocation(parentTile.getCoordinates());
                 delayGoToItem.pulse();
             }
         }else {
-            double distance = World.getPlayer().getLocation().getDistance(mouseTile.getCoordinates());
-            log.trace("Clicked tile {} is outside of use range, walking to it.", mouseTile);
-            log.trace("The distance from the player to the tile is " + distance);
             handler.walkTo(mouseTile.getCoordinates(), (mouseTileIsBlocked ? 1 : 0));
             handler.assumeControl();
         }
@@ -344,16 +336,13 @@ public final class Item extends AbstractEntity<ItemTemplate> implements Resource
         boolean useRange = parentTile.getInteractive().isInUseRange();
 
         if (useRange) {
-            log.trace("Clicked item {} is inside of use range.", getItemId());
             if (blocked) {
                 return true;
             } else {
-                log.trace("Clicked item {} allows walking to. Delaying move to accept double click.", getItemId());
                 delayGoToItem.setLocation(parentTile.getCoordinates());
                 delayGoToItem.pulse();
             }
         } else {
-            log.trace("Clicked item {} is outside of use range.", getItemId());
             if (blocked) {
                 handler.walkTo(parentTile.getCoordinates(), 1);
             } else {
@@ -375,13 +364,10 @@ public final class Item extends AbstractEntity<ItemTemplate> implements Resource
 
         delayGoToItem.reset();
 
-        log.trace("Double clicking item: {}", getItemId());
 
         if (parentTile.getInteractive().isInUseRange()) {
-            log.trace("Item {} is within use range. Using it!", getItemId());
             parentTile.getInteractive().use();
         } else {
-            log.trace("Item {} is outside of the use range. Walking to it.", getItemId());
             final InteractiveMapTile interactiveMapTile = parentTile.getInteractive();
             TargetMovementHandler handler = World.getPlayer().getMovementHandler().getTargetMovementHandler();
             handler.walkTo(parentTile.getCoordinates(), 1);

--- a/illaclient/src/main/java/illarion/client/world/Char.java
+++ b/illaclient/src/main/java/illarion/client/world/Char.java
@@ -639,7 +639,7 @@ public final class Char implements AnimatedMove {
      */
     private void updateLight(@Nullable Avatar avatar, int mode) {
         if (removedCharacter) {
-            log.warn("Trying to update the light of a removed character.");
+            log.error("Trying to update the light of a removed character.");
             return;
         }
         if (coordinate == null) {
@@ -1046,8 +1046,6 @@ public final class Char implements AnimatedMove {
     }
 
     private boolean updateLocation(@Nonnull ServerCoordinate newLocation) {
-        // get old position
-
         if (newLocation.equals(coordinate)) {
             return false;
         }
@@ -1344,10 +1342,11 @@ public final class Char implements AnimatedMove {
      */
     public void updateLight() {
         if (coordinate == null) {
-            throw new IllegalStateException("The position of the character is not set. The light can't be updated.");
+            log.error("The position of the character is not set. The light can't be updated.");
+            return;
         }
         if (removedCharacter) {
-            log.warn("Trying to update the light of a removed character.");
+            log.error("Trying to update the light of a removed character.");
             return;
         }
         if (lightValue > 0) {

--- a/illaclient/src/main/java/illarion/client/world/Char.java
+++ b/illaclient/src/main/java/illarion/client/world/Char.java
@@ -1342,11 +1342,11 @@ public final class Char implements AnimatedMove {
      */
     public void updateLight() {
         if (coordinate == null) {
-            log.error("The position of the character is not set. The light can't be updated.");
+            log.warn("The position of the character is not set. The light can't be updated.");
             return;
         }
         if (removedCharacter) {
-            log.error("Trying to update the light of a removed character.");
+            log.warn("Trying to update the light of a removed character.");
             return;
         }
         if (lightValue > 0) {

--- a/illaclient/src/main/java/illarion/client/world/People.java
+++ b/illaclient/src/main/java/illarion/client/world/People.java
@@ -323,11 +323,11 @@ public final class People {
                     if (character.getLocation().equals(coordinate)) {
                         return character;
                     }
-                }catch(NullPointerException ex) {
+                } catch(NullPointerException ex) {
                     // Do nothing, this character isn't at the right location if it is at null anyway
                 }
             }
-        }finally {
+        } finally {
             charsLock.readLock().unlock();
         }
 

--- a/illaclient/src/main/java/illarion/client/world/People.java
+++ b/illaclient/src/main/java/illarion/client/world/People.java
@@ -318,13 +318,16 @@ public final class People {
 
         charsLock.readLock().lock();
         try {
-
             for (Char character : chars.values()) {
-                if (character.getLocation().equals(coordinate)) {
-                    return character;
+                try {
+                    if (character.getLocation().equals(coordinate)) {
+                        return character;
+                    }
+                }catch(NullPointerException ex) {
+                    // Do nothing, this character isn't at the right location if it is at null anyway
                 }
             }
-        } finally {
+        }finally {
             charsLock.readLock().unlock();
         }
 

--- a/illaclient/src/main/java/illarion/client/world/interactive/InteractiveMapTile.java
+++ b/illaclient/src/main/java/illarion/client/world/interactive/InteractiveMapTile.java
@@ -200,7 +200,7 @@ public class InteractiveMapTile implements Draggable, DropTarget, Usable {
     public boolean isInUseRange() {
         @Nonnull ServerCoordinate playerLocation = World.getPlayer().getMovementHandler().getServerLocation();
         if (playerLocation.getZ() == getLocation().getZ()) {
-            return playerLocation.getDistance(getLocation()) <= getUseRange();
+            return ((int) playerLocation.getDistance(getLocation())) <= getUseRange();
         }
         return false;
     }

--- a/illaclient/src/main/java/illarion/client/world/interactive/InteractiveMapTile.java
+++ b/illaclient/src/main/java/illarion/client/world/interactive/InteractiveMapTile.java
@@ -200,7 +200,7 @@ public class InteractiveMapTile implements Draggable, DropTarget, Usable {
     public boolean isInUseRange() {
         @Nonnull ServerCoordinate playerLocation = World.getPlayer().getMovementHandler().getServerLocation();
         if (playerLocation.getZ() == getLocation().getZ()) {
-            return ((int) playerLocation.getDistance(getLocation())) <= getUseRange();
+            return ( playerLocation.getStepDistance(getLocation())) <= getUseRange();
         }
         return false;
     }

--- a/illagameengine/src/main/java/org/illarion/engine/graphic/GraphicResolution.java
+++ b/illagameengine/src/main/java/org/illarion/engine/graphic/GraphicResolution.java
@@ -52,22 +52,17 @@ public final class GraphicResolution {
 
     /**
      * Default Constructor for a graphic resolution definition.
-     * Sets width = (the local screen width) * 0.75
-     * height = (the local screen height) * 0.75
+     * Sets width = (the local screen width) * 0.95
+     * height = (the local screen height) * 0.95
      * refreshRate = local refreshRate;
      */
     public GraphicResolution(){
         GraphicsEnvironment environment = GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsDevice gd = environment.getDefaultScreenDevice();
         DisplayMode dm = gd.getDisplayMode();
-        // Sets the width and height equal to the screen.
-        // To keep the non-fullscreen version from taking up the whole screen, multiply by 0.75
-        height = (int) (dm.getHeight() * 0.75);
-        width = (int) (dm.getWidth() * 0.75);
-        // Automatically detect refresh rate
+        height = (int) (dm.getHeight() * 0.95);
+        width = (int) (dm.getWidth() * 0.95);
         refreshRate = dm.getRefreshRate();
-        // Take the Screen Resolution of the client computer
-        // Fetches the local Bit Depth in Bits-Per-Pixel
         bpp = dm.getBitDepth();
     }
     /**


### PR DESCRIPTION
10875: 
Handles most crashes that were brought on by null values in a character's ServerCoordinates

10277: 
Moved the processMapClick() method down to the Item class from AbstractEntity when it became apparent that it needed the ability to work with some items, specifically doors. 
InteractiveMapTile's isInUseRange() was returning improper values for points diagonal to the player. Casting distance to an int corrects this problem. 

