### PR TITLE
[Client Issue 0011102] Hide error message on relog after disconnect.

### DIFF
--- a/illaclient/src/main/java/illarion/client/gui/controller/game/DisconnectHandler.java
+++ b/illaclient/src/main/java/illarion/client/gui/controller/game/DisconnectHandler.java
@@ -122,9 +122,7 @@ public class DisconnectHandler implements ScreenController, UpdatableHandler, Ev
 
     @Override
     public void onEvent(@Nonnull String topic, @Nonnull ButtonClickedEvent data) {
-        //if (tryToReconnect) {
-        //    //IllaClient.returnToLogin();
-        //}
+        popup.hide();
         IllaClient.returnToLogin();
     }
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -17,7 +17,7 @@ ext {
     slf4jVersion = '1.7.12'
     logbackVersion = '1.1.3'
     janinoVersion = '2.7.8'
-    illarionResourcesVersion = '2.1.24'
+    illarionResourcesVersion = '2.1.24-SNAPSHOT'
     niftyGuiVersion = '1.4.1'
     insubstantialVersion = '7.3'
 }


### PR DESCRIPTION
Hides the error message popup when "OK" is clicked, before returning to login screen.