### PR TITLE
[Client Issue 0011102] Close the dialogue when "OK" is clicked on disconnect

### DIFF
--- a/illaclient/src/main/java/illarion/client/gui/controller/game/DisconnectHandler.java
+++ b/illaclient/src/main/java/illarion/client/gui/controller/game/DisconnectHandler.java
@@ -122,9 +122,7 @@ public class DisconnectHandler implements ScreenController, UpdatableHandler, Ev
 
     @Override
     public void onEvent(@Nonnull String topic, @Nonnull ButtonClickedEvent data) {
-        //if (tryToReconnect) {
-        //    //IllaClient.returnToLogin();
-        //}
+        popup.hide();
         IllaClient.returnToLogin();
     }
 }


### PR DESCRIPTION
Just hides the message box before returning to the login screen.