### PR TITLE
Dynamic client resource resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,17 @@ allprojects {
         resolutionStrategy {
             cacheDynamicVersionsFor 10 * 60, 'seconds'
             cacheChangingModulesFor 0, 'seconds'
+
+            componentSelection {
+                all { ComponentSelection selection ->
+                    if (selection.candidate.group == 'org.illarion' &&
+                            selection.candidate.module.startsWith('rsc_') &&
+                            !selection.candidate.version.endsWith('-SNAPSHOT') &&
+                            project.ext.branch != 'master') {
+                        selection.reject("only snapshot versions on dev")
+                    }
+                }
+            }
         }
     }
 

--- a/illaclient/build.gradle
+++ b/illaclient/build.gradle
@@ -38,15 +38,15 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.0'
     compile group: 'com.google.guava', name: 'guava', version: '21.0'
     compile group: 'com.github.nifty-gui', name: 'nifty', version: project.ext.niftyGuiVersion
-    runtime group: 'org.illarion', name: 'rsc_books', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_chars', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_effects', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_gui', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_items', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_music', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_sounds', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_tables', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_tiles', version: project.ext.illarionResourcesVersion
+    runtime group: 'org.illarion', name: 'rsc_books', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_chars', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_effects', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_gui', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_items', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_music', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_sounds', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_tables', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_tiles', version: project.ext.illarionResourcesVersion, changing: true
 }
 
 jar {

--- a/illadownload/src/main/java/illarion/download/maven/MavenDownloader.java
+++ b/illadownload/src/main/java/illarion/download/maven/MavenDownloader.java
@@ -56,6 +56,9 @@ import org.eclipse.aether.util.filter.DependencyFilterUtils;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.selector.OptionalDependencySelector;
 import org.eclipse.aether.util.graph.selector.ScopeDependencySelector;
+import org.eclipse.aether.util.graph.version.ChainedVersionFilter;
+import org.eclipse.aether.util.graph.version.HighestVersionFilter;
+import org.eclipse.aether.util.graph.version.SnapshotVersionFilter;
 import org.eclipse.aether.util.graph.visitor.FilteringDependencyVisitor;
 import org.eclipse.aether.util.graph.visitor.TreeDependencyVisitor;
 import org.slf4j.Logger;
@@ -168,6 +171,12 @@ public class MavenDownloader {
         session.setConfigProperty(ConfigurationProperties.REQUEST_TIMEOUT, requestTimeOut);
         session.setUpdatePolicy(UPDATE_POLICY_ALWAYS);
         session.setChecksumPolicy(CHECKSUM_POLICY_FAIL);
+
+        if (snapshot) {
+            session.setVersionFilter(ChainedVersionFilter.newInstance(new OnlySnapshotVersionFilter(), new HighestVersionFilter()));
+        } else {
+            session.setVersionFilter(ChainedVersionFilter.newInstance(new SnapshotVersionFilter(), new HighestVersionFilter()));
+        }
 
         log.info("Used request timeout: {}ms", requestTimeOut);
 

--- a/illadownload/src/main/java/illarion/download/maven/OnlySnapshotVersionFilter.java
+++ b/illadownload/src/main/java/illarion/download/maven/OnlySnapshotVersionFilter.java
@@ -1,0 +1,42 @@
+package illarion.download.maven;
+
+import java.util.Iterator;
+
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.VersionFilter;
+import org.eclipse.aether.version.Version;
+
+/**
+ * A version filter that (unconditionally) blocks non "*-SNAPSHOT" versions.
+ */
+public final class OnlySnapshotVersionFilter implements VersionFilter {
+    public void filterVersions( VersionFilterContext context ) {
+        for ( Iterator<Version> it = context.iterator(); it.hasNext(); )
+        {
+            String version = it.next().toString();
+            if ( !version.endsWith( "SNAPSHOT" ) )
+            {
+                it.remove();
+            }
+        }
+    }
+
+    public VersionFilter deriveChildFilter( DependencyCollectionContext context ) {
+        return this;
+    }
+
+    @Override
+    public boolean equals( Object obj ) {
+        if ( this == obj )
+        {
+            return true;
+        }
+
+        return null != obj && getClass().equals(obj.getClass());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/illaeasynpc/build.gradle
+++ b/illaeasynpc/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 
     antlr4 group: 'org.antlr', name: 'antlr4', version: '4.7'
 
-    runtime group: 'org.illarion', name: 'rsc_tables', version: project.ext.illarionResourcesVersion
+    runtime group: 'org.illarion', name: 'rsc_tables', version: project.ext.illarionResourcesVersion, changing: true
 }
 
 task antlrOutputDir {

--- a/illamapedit/build.gradle
+++ b/illamapedit/build.gradle
@@ -36,10 +36,10 @@ dependencies {
     compile group: 'com.github.insubstantial', name: 'substance', version: project.ext.insubstantialVersion
     compile group: 'com.github.insubstantial', name: 'substance-flamingo', version: project.ext.insubstantialVersion
     compile group: 'com.github.insubstantial', name: 'substance-swingx', version: project.ext.insubstantialVersion
-    runtime group: 'org.illarion', name: 'rsc_items', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_music', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_tables', version: project.ext.illarionResourcesVersion
-    runtime group: 'org.illarion', name: 'rsc_tiles', version: project.ext.illarionResourcesVersion
+    runtime group: 'org.illarion', name: 'rsc_items', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_music', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_tables', version: project.ext.illarionResourcesVersion, changing: true
+    runtime group: 'org.illarion', name: 'rsc_tiles', version: project.ext.illarionResourcesVersion, changing: true
 }
 
 jar {

--- a/versions.gradle
+++ b/versions.gradle
@@ -17,7 +17,7 @@ ext {
     slf4jVersion = '1.7.25'
     logbackVersion = '1.2.2'
     janinoVersion = '3.0.7'
-    illarionResourcesVersion = '2.1.26-SNAPSHOT'
+    illarionResourcesVersion = '[2.0, )'
     niftyGuiVersion = '1.4.2'
     insubstantialVersion = '7.3'
 }


### PR DESCRIPTION
- Set [2.0, ) to be the allowed version for the illarion resources to allow auto update to the newest (snapshot) version once its available
- Made adjustments to the downloader so that it will always download the latest version thats the correct one for its branch (release/dev)