### PR TITLE
Use https in downloader

### DIFF
--- a/illadownload/src/main/java/illarion/download/maven/MavenDownloader.java
+++ b/illadownload/src/main/java/illarion/download/maven/MavenDownloader.java
@@ -281,16 +281,11 @@ public class MavenDownloader {
     }
 
     private void setupRepositories() {
-        repositories.add(setupRepository("central", "http://repo1.maven.org/maven2/",
-                setupRepository("ibiblio.org", "http://mirrors.ibiblio.org/maven2/"),
-                setupRepository("antelink", ".com/content/repositories/central/"),
-                setupRepository("exist", "http://repo.exist.com/maven2/"),
-                setupRepository("ibiblio.net", "http://www.ibiblio.net/pub/packages/maven2/"),
-                setupRepository("central-uk", "http://uk.maven.org/maven2/")));
+        repositories.add(setupRepository("central", "https://repo1.maven.org/maven2/",
+                setupRepository("antelink", ".com/content/repositories/central/")));
 
         illarionRepository = setupRepository("illarion", "https://illarion.org/media/java/maven", true, snapshot);
         repositories.add(illarionRepository);
-        repositories.add(setupRepository("oss-sonatype", "http://oss.sonatype.org/content/repositories/releases/"));
 
         session.setOffline(offline);
 


### PR DESCRIPTION
I removed some old repositories that could no longer be used anyway.
I switched from http maven to https so this repository can be used again. I fear that the launcher was getting all dependencies from our server because the http connection to maven central failed. That resulted in the long startup time of the launcher.